### PR TITLE
Add an explicit reference to Json.Net in order for the Wix setup proj…

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -61,6 +61,10 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SmartFormat, Version=1.6.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SmartFormat.NET.1.6.1.0\lib\net40-Client\SmartFormat.dll</HintPath>
       <Private>True</Private>

--- a/GitExtensions/packages.config
+++ b/GitExtensions/packages.config
@@ -3,5 +3,6 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40-Client" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40-Client" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40-Client" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40-Client" />
   <package id="SmartFormat.NET" version="1.6.1.0" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
…ect to build
- the Wix setup is looking for "..\GitExtensions\bin\Release\Newtownsoft.Json.dll" which is not copied by default
